### PR TITLE
Bugfix for Android 5.0 Lollipop (API 21)

### DIFF
--- a/src/com/github/notizklotz/derbunddownloader/main/ManuallyDownloadIssueDatePickerFragment.java
+++ b/src/com/github/notizklotz/derbunddownloader/main/ManuallyDownloadIssueDatePickerFragment.java
@@ -50,10 +50,6 @@ public class ManuallyDownloadIssueDatePickerFragment extends DialogFragment {
         final DatePicker datePicker = datePickerDialog.getDatePicker();
         assert datePicker != null;
 
-        CalendarView calendarView = datePicker.getCalendarView();
-        if (calendarView != null) {
-            calendarView.setFirstDayOfWeek(Calendar.MONDAY);
-        }
         datePicker.setMaxDate(System.currentTimeMillis());
 
         //Override the OK button instead of using the OnDateSetListener callback due to bug https://code.google.com/p/android/issues/detail?id=34833


### PR DESCRIPTION
Lollipop used to fail with an UnsupportedOperationException on datePicker.getCalendarView(). I just removed these lines to make it work in Lollipop as well.
